### PR TITLE
Substituents

### DIFF
--- a/geomtools/fileio.py
+++ b/geomtools/fileio.py
@@ -86,7 +86,10 @@ def read_col(infile, units='bohr', hasmom=False, hascom=False):
                 break
     elem = data[:, 0]
     xyz = data[:, 2:5].astype(float) * con.conv(units, 'ang')
-    mom = np.zeros_like(xyz)
+    if hasmom:
+        mom = np.zeros_like(xyz)
+    else:
+        mom = None
     return elem, xyz, mom, comment
 
 

--- a/geomtools/fileio.py
+++ b/geomtools/fileio.py
@@ -11,19 +11,19 @@ import geomtools.constants as con
 import geomtools.displace as displace
 
 
-def read_xyz(infile, units='ang', hasmom=False, hascom=False):
+def read_xyz(infile, units='ang', hasvec=False, hascom=False):
     """Reads input file in XYZ format.
 
     XYZ files are in the format:
     natm
     comment
-    A X1 Y1 Z1 [Px1 Py1 Pz1]
-    B X2 Y2 Z2 [Px2 Py2 Pz2]
+    A X1 Y1 Z1 [Vx1 Vy1 Vz1]
+    B X2 Y2 Z2 [Vx2 Vy2 Vz2]
     ...
     where natm is the number of atoms, comment is a comment line, A and B
     are atomic labels and X, Y and Z are cartesian coordinates (in
-    Angstroms). The momenta Px, Py and Pz are optional and will only be
-    read if hasmom = True.
+    Angstroms). The vectors Vx, Vy and Vz are optional and will only be
+    read if hasvec = True.
 
     Due to the preceding number of atoms, multiple XYZ format geometries
     can easily be read from a single file.
@@ -40,14 +40,14 @@ def read_xyz(infile, units='ang', hasmom=False, hascom=False):
     data = np.array([infile.readline().split() for i in range(natm)])
     elem = data[:, 0]
     xyz = data[:, 1:4].astype(float) * con.conv(units, 'ang')
-    if hasmom:
-        mom = data[:, 4:7].astype(float)
+    if hasvec:
+        vec = data[:, 4:7].astype(float)
     else:
-        mom = None
-    return elem, xyz, mom, comment
+        vec = None
+    return elem, xyz, vec, comment
 
 
-def read_col(infile, units='bohr', hasmom=False, hascom=False):
+def read_col(infile, units='bohr', hasvec=False, hascom=False):
     """Reads input file in COLUMBUS format.
 
     COLUMBUS geometry files are in the format:
@@ -62,7 +62,7 @@ def read_col(infile, units='bohr', hasmom=False, hascom=False):
     geometry. A comment line (or blank line) must be used to separate
     molecules.
 
-    For the time being, momentum input is not supported for the
+    For the time being, vector input is not supported for the
     COLUMBUS file format.
     """
     if hascom:
@@ -86,14 +86,14 @@ def read_col(infile, units='bohr', hasmom=False, hascom=False):
                 break
     elem = data[:, 0]
     xyz = data[:, 2:5].astype(float) * con.conv(units, 'ang')
-    if hasmom:
-        mom = np.zeros_like(xyz)
+    if hasvec:
+        vec = np.zeros_like(xyz)
     else:
-        mom = None
-    return elem, xyz, mom, comment
+        vec = None
+    return elem, xyz, vec, comment
 
 
-def read_gdat(infile, units='bohr', hasmom=False, hascom=False):
+def read_gdat(infile, units='bohr', hasvec=False, hascom=False):
     """Reads input file in FMS90 Geometry.dat format.
 
     Geometry.dat files are in the format:
@@ -102,13 +102,13 @@ def read_gdat(infile, units='bohr', hasmom=False, hascom=False):
     A X1 Y1 Z1
     B X2 Y2 Z2
     ...
-    Px1 Py1 Pz1
-    Px2 Py2 Pz2
+    Vx1 Vy1 Vz1
+    Vx2 Vy2 Vz2
     ...
     where comment is a comment line, natm is the number of atoms, A and B
-    are atomic labels, X, Y and Z are cartesian coordinates and Pq are
-    momenta for cartesian coordinates q. The momenta are only read if
-    hasmom = True.
+    are atomic labels, X, Y and Z are cartesian coordinates and Vq are
+    vectors for cartesian coordinates q. The vectors are only read if
+    hasvec = True.
     """
     if hascom:
         comment = infile.readline().strip()
@@ -122,15 +122,15 @@ def read_gdat(infile, units='bohr', hasmom=False, hascom=False):
     data = np.array([infile.readline().split() for i in range(natm)])
     elem = data[:, 0]
     xyz = data[:, 1:].astype(float) * con.conv(units, 'ang')
-    if hasmom:
-        mom = np.array([infile.readline().split() for i in range(natm)],
+    if hasvec:
+        vec = np.array([infile.readline().split() for i in range(natm)],
                        dtype=float)
     else:
-        mom = None
-    return elem, xyz, mom, comment
+        vec = None
+    return elem, xyz, vec, comment
 
 
-def read_zmt(infile, units='ang', hasmom=False, hascom=False):
+def read_zmt(infile, units='ang', hasvec=False, hascom=False):
     """Reads input file in Z-matrix format.
 
     Z-matrix files are in the format:
@@ -152,7 +152,7 @@ def read_zmt(infile, units='ang', hasmom=False, hascom=False):
     first atom allows multiple geometries to be read without separation
     by a comment line.
 
-    For the time being, momentum input is not supported for the
+    For the time being, vector input is not supported for the
     Z-matrix file format.
     """
     if hascom:
@@ -226,24 +226,24 @@ def read_zmt(infile, units='ang', hasmom=False, hascom=False):
                                   ind=i, origin=xyz[indR], units='deg')
 
     xyz = displace.centre_mass(elem, xyz) * con.conv(units, 'ang')
-    if hasmom:
-        mom = np.zeros_like(xyz)
+    if hasvec:
+        vec = np.zeros_like(xyz)
     else:
-        mom = None
-    return elem, xyz, mom, comment
+        vec = None
+    return elem, xyz, vec, comment
 
 
-def read_trajdump(infile, units='bohr', hasmom=False, hascom=False,
+def read_trajdump(infile, units='bohr', hasvec=False, hascom=False,
                   elem=None, time=None):
     """Reads input file in FMS90/FMSpy TrajDump format
 
     TrajDump files are in the format:
-    T1 X1 Y1 Z1 X2 Y2 ... Px1 Py1 Pz1 Px2 Py2 ... G Re(A) Im(A) |A| S
-    T2 X1 Y1 Z1 X2 Y2 ... Px1 Py1 Pz1 Px2 Py2 ... G Re(A) Im(A) |A| S
+    T1 X1 Y1 Z1 X2 Y2 ... Vx1 Vy1 Vz1 Vx2 Vy2 ... G Re(A) Im(A) |A| S
+    T2 X1 Y1 Z1 X2 Y2 ... Vx1 Vy1 Vz1 Vx2 Vy2 ... G Re(A) Im(A) |A| S
     ...
-    where T is the time, Pq are the momenta for cartesian coordinates q,
-    G is the phase, A is the amplitude and S is the state label. The momenta
-    are only read if hasmom = True.
+    where T is the time, Vq are the vectors (momenta) for cartesian
+    coordinates q, G is the phase, A is the amplitude and S is the state
+    label. The vectors are only read if hasvec = True.
 
     TrajDump files do not contain atomic labels. If not provided, they are
     set to dummy atoms which may affect calculations involving atomic
@@ -270,11 +270,11 @@ def read_trajdump(infile, units='bohr', hasmom=False, hascom=False,
     if elem is None:
         elem = np.array(['X'] * natm)
     xyz = line[1:3*natm+1].reshape(natm, 3) * con.conv(units,'ang')
-    if hasmom:
-        mom = line[3*natm+1:6*natm+1].reshape(natm, 3)
+    if hasvec:
+        vec = line[3*natm+1:6*natm+1].reshape(natm, 3)
     else:
-        mom = None
-    return elem, xyz, mom, comment
+        vec = None
+    return elem, xyz, vec, comment
 
 
 def read_auto(infile, hascom=False, **kwargs):
@@ -358,24 +358,24 @@ def _valvar(unk, vardict):
             raise KeyError('\'{}\' not found in variable list'.format(unk))
 
 
-def write_xyz(outfile, elem, xyz, mom=None, comment='', units='ang'):
+def write_xyz(outfile, elem, xyz, vec=None, comment='', units='ang'):
     """Writes geometry to an output file in XYZ format."""
     natm = len(elem)
     write_xyz = xyz * con.conv('ang', units)
     outfile.write(' {}\n{}\n'.format(natm, comment))
-    if mom is None:
+    if vec is None:
         for atm, xyzi in zip(elem, write_xyz):
             outfile.write('{:4s}{:12.6f}{:12.6f}{:12.6f}\n'.format(atm, *xyzi))
     else:
-        for atm, xyzi, pxyzi in zip(elem, write_xyz, mom):
+        for atm, xyzi, pxyzi in zip(elem, write_xyz, vec):
             outfile.write('{:4s}{:12.6f}{:12.6f}{:12.6f}'.format(atm, *xyzi) +
                           '{:12.6f}{:12.6f}{:12.6f}\n'.format(*pxyzi))
 
 
-def write_col(outfile, elem, xyz, mom=None, comment='', units='bohr'):
+def write_col(outfile, elem, xyz, vec=None, comment='', units='bohr'):
     """Writes geometry to an output file in COLUMBUS format.
 
-    For the time being, momentum output is not supported for the
+    For the time being, vector output is not supported for the
     COLUMBUS file format.
     """
     write_xyz = xyz * con.conv('ang', units)
@@ -387,28 +387,28 @@ def write_col(outfile, elem, xyz, mom=None, comment='', units='bohr'):
                                   con.get_mass(atm)))
 
 
-def write_gdat(outfile, elem, xyz, mom=None, comment='', units='bohr'):
+def write_gdat(outfile, elem, xyz, vec=None, comment='', units='bohr'):
     """Writes geometry to an output file in Geometry.dat format."""
     natm = len(elem)
     write_xyz = xyz * con.conv('ang', units)
     outfile.write('{}\n{}\n'.format(comment, natm))
     for atm, xyzi in zip(elem, write_xyz):
         outfile.write('{:<2s}{:18.8E}{:18.8E}{:18.8E}\n'.format(atm, *xyzi))
-    if mom is None:
+    if vec is None:
         for line in range(natm):
             outfile.write(' {:18.8E}{:18.8E}{:18.8E}\n'.format(0, 0, 0))
     else:
-        for pxyzi in mom:
+        for pxyzi in vec:
             outfile.write(' {:18.8E}{:18.8E}{:18.8E}\n'.format(*pxyzi))
 
 
-def write_zmt(outfile, elem, xyz, mom=None, comment='', units='ang'):
+def write_zmt(outfile, elem, xyz, vec=None, comment='', units='ang'):
     """Writes geometry to an output file in Z-matrix format.
 
     TODO: At present, each atom uses the previous atoms in order as
     references. This could be made 'smarter' using the bonding module.
 
-    For the time being, momentum output is not supported for the
+    For the time being, vector output is not supported for the
     Z-matrix file format.
     """
     natm = len(elem)
@@ -442,11 +442,11 @@ def write_zmt(outfile, elem, xyz, mom=None, comment='', units='ang'):
                                                          units='deg')))
 
 
-def write_zmtvar(outfile, elem, xyz, mom=None, comment='', units='ang'):
+def write_zmtvar(outfile, elem, xyz, vec=None, comment='', units='ang'):
     """Writes geometry to an output file in Z-matrix format with
     variable assignments.
 
-    For the time being, momentum output is not supported for the
+    For the time being, vector output is not supported for the
     Z-matrix file format.
     """
     natm = len(elem)
@@ -505,7 +505,7 @@ def write_auto(outfile, elem, xyz, **kwargs):
 
 
 def convert(infname, outfname, infmt='auto', outfmt='auto',
-            inunits=None, outunits=None, hasmom=False, hascom=False):
+            inunits=None, outunits=None, hasvec=False, hascom=False):
     """Reads a file in format infmt and writes to a file in format
     outfmt.
 
@@ -513,9 +513,9 @@ def convert(infname, outfname, infmt='auto', outfmt='auto',
     ordering is not conserved.
     """
     if inunits is None:
-        inkw = dict(hasmom=hasmom, hascom=hascom)
+        inkw = dict(hasvec=hasvec, hascom=hascom)
     else:
-        inkw = dict(hasmom=hasmom, hascom=hascom, units=inunits)
+        inkw = dict(hasvec=hasvec, hascom=hascom, units=inunits)
     if outunits is None:
         outkw = dict()
     else:
@@ -526,9 +526,9 @@ def convert(infname, outfname, infmt='auto', outfmt='auto',
     with open(infname, 'r') as infile, open(outfname, 'w') as outfile:
         while True:
             try:
-                elem, xyz, mom, comment = read_func(infile, **inkw)
-                if hasmom:
-                    outkw.update(mom = mom)
+                elem, xyz, vec, comment = read_func(infile, **inkw)
+                if hasvec:
+                    outkw.update(vec = vec)
                 if hascom:
                     outkw.update(comment = comment)
                 write_func(outfile, elem, xyz, **outkw)

--- a/geomtools/molecule.py
+++ b/geomtools/molecule.py
@@ -396,10 +396,10 @@ class Molecule(BaseMolecule):
                         self.get_comment()), ind
 
     # Functional group substitution
-    def subst(self, lbl, isub, ibond, iplane=None):
+    def subst(self, lbl, isub, ibond, pl=None):
         """Replaces an atom or set of atoms with a substituent."""
         args = (self.elem, self.xyz, lbl, isub, ibond)
-        kwargs = dict(iplane=iplane, mom=self.mom)
+        kwargs = dict(pl=pl, mom=self.mom)
         self.elem, self.xyz, self.mom = substitute.subst(*args, **kwargs)
 
 

--- a/geomtools/molecule.py
+++ b/geomtools/molecule.py
@@ -396,10 +396,10 @@ class Molecule(BaseMolecule):
                         self.get_comment()), ind
 
     # Functional group substitution
-    def subst(self, lbl, isub, ibond, pl=None):
+    def subst(self, lbl, isub, ibond=None, pl=None):
         """Replaces an atom or set of atoms with a substituent."""
-        args = (self.elem, self.xyz, lbl, isub, ibond)
-        kwargs = dict(pl=pl, vec=self.vec)
+        args = (self.elem, self.xyz, lbl, isub)
+        kwargs = dict(ibond=ibond, pl=pl, vec=self.vec)
         self.elem, self.xyz, self.vec = substitute.subst(*args, **kwargs)
 
 

--- a/geomtools/molecule.py
+++ b/geomtools/molecule.py
@@ -26,28 +26,28 @@ class BaseMolecule(object):
     geometry. There are no dependancies to other geomtools modules.
     """
     def __init__(self, elem=np.array([], dtype=str), xyz=np.empty((0, 3)),
-                 mom=None, comment=''):
+                 vec=None, comment=''):
         self.elem = np.array(elem, dtype=str)
         self.xyz = np.array(xyz, dtype=float)
         self.comment = comment
         self.natm = len(elem)
-        if mom is None:
-            self.mom = np.zeros((self.natm, 3))
-            self.print_mom = False
+        if vec is None:
+            self.vec = np.zeros((self.natm, 3))
+            self.print_vec = False
         else:
-            self.mom = np.array(mom, dtype=float)
-            self.print_mom = True
+            self.vec = np.array(vec, dtype=float)
+            self.print_vec = True
         self.saved = True
         self.save()
 
     def __repr__(self):
         nelem = len(self.elem)
         fmt = '[{:>2s},' + 2*'{:16.8e},' + '{:16.8e}'
-        if self.print_mom:
-            xyzmom = np.hstack((self.xyz, self.mom))
+        if self.print_vec:
+            xyzvec = np.hstack((self.xyz, self.vec))
             fmt += ',\n' + 6*' ' + 2*'{:16.8e},' + '{:16.8e}]'
         else:
-            xyzmom = self.xyz
+            xyzvec = self.xyz
             fmt += ']'
 
         if nelem == 0:
@@ -56,17 +56,17 @@ class BaseMolecule(object):
             fstr = 'BaseMolecule({!r},\n ['.format(self.comment)
 
         if nelem > 10:
-            fstr += fmt.format(self.elem[0], *xyzmom[0])
+            fstr += fmt.format(self.elem[0], *xyzvec[0])
             for i in range(1, 3):
-                fstr += ',\n  ' + fmt.format(self.elem[i], *xyzmom[i])
+                fstr += ',\n  ' + fmt.format(self.elem[i], *xyzvec[i])
             fstr += ',\n  ...'
             for i in range(-3, 0):
-                fstr += ',\n  ' + fmt.format(self.elem[i], *xyzmom[i])
+                fstr += ',\n  ' + fmt.format(self.elem[i], *xyzvec[i])
         else:
             for i in range(nelem):
                 if i != 0:
                     fstr += ',\n  '
-                fstr += fmt.format(self.elem[i], *xyzmom[i])
+                fstr += fmt.format(self.elem[i], *xyzvec[i])
 
         fstr += '])'
         return fstr
@@ -74,11 +74,11 @@ class BaseMolecule(object):
     def __str__(self):
         nelem = len(self.elem)
         fmt = '[{:>2s}' + 3*'{:14.8f}'
-        if self.print_mom:
-            xyzmom = np.hstack((self.xyz, self.mom))
+        if self.print_vec:
+            xyzvec = np.hstack((self.xyz, self.vec))
             fmt += '\n' + 4*' ' + 3*'{:14.8f}' + ']'
         else:
-            xyzmom = self.xyz
+            xyzvec = self.xyz
             fmt += ']'
         fstr = ''
         if self.comment != '':
@@ -86,17 +86,17 @@ class BaseMolecule(object):
         else:
             fstr += '['
         if nelem > 10:
-            fstr += fmt.format(self.elem[0], *xyzmom[0])
+            fstr += fmt.format(self.elem[0], *xyzvec[0])
             for i in range(1, 3):
-                fstr += '\n ' + fmt.format(self.elem[i], *xyzmom[i])
+                fstr += '\n ' + fmt.format(self.elem[i], *xyzvec[i])
             fstr += '\n ...'
             for i in range(-3, 0):
-                fstr += '\n ' + fmt.format(self.elem[i], *xyzmom[i])
+                fstr += '\n ' + fmt.format(self.elem[i], *xyzvec[i])
         else:
             for i in range(nelem):
                 if i != 0:
                     fstr += '\n '
-                fstr += fmt.format(self.elem[i], *xyzmom[i])
+                fstr += fmt.format(self.elem[i], *xyzvec[i])
         fstr += ']'
         return fstr
 
@@ -104,16 +104,16 @@ class BaseMolecule(object):
         """Checks that xyz is 3D and len(elem) = len(xyz)."""
         if self.xyz.shape[1] != 3:
             raise ValueError('Molecular geometry must be 3-dimensional.')
-        if self.mom.shape[1] != 3:
-            raise ValueError('Molecular momentum must be 3-dimensional.')
+        if self.vec.shape[1] != 3:
+            raise ValueError('Molecular vector must be 3-dimensional.')
         len_elem = len(self.elem)
         len_xyz = len(self.xyz)
         if len_elem != len_xyz:
             raise ValueError('Number of element labels ({:d}) not equal '
                              'to number of cartesian vectors '
                              '({:d}).'.format(len_elem, len_xyz))
-        elif self.xyz.shape != self.mom.shape:
-            raise ValueError('Cartesian geometry and momenta must have '
+        elif self.xyz.shape != self.vec.shape:
+            raise ValueError('Cartesian geometry and vector must have '
                              'the same number of elements.')
 
     def copy(self, comment=None):
@@ -122,14 +122,14 @@ class BaseMolecule(object):
         if comment is None:
             comment = 'Copy of ' + self.comment
         return BaseMolecule(np.copy(self.elem), np.copy(self.xyz),
-                            np.copy(self.mom), comment)
+                            np.copy(self.vec), comment)
 
     def save(self):
         """Saves molecular properties to 'orig' variables."""
         self._check()
         self.orig_elem = np.copy(self.elem)
         self.orig_xyz = np.copy(self.xyz)
-        self.orig_mom = np.copy(self.mom)
+        self.orig_vec = np.copy(self.vec)
         self.orig_comment = np.copy(self.comment)
         self.saved = True
 
@@ -138,7 +138,7 @@ class BaseMolecule(object):
         if not self.saved:
             self.elem = np.copy(self.orig_elem)
             self.xyz = np.copy(self.orig_xyz)
-            self.mom = np.copy(self.orig_mom)
+            self.vec = np.copy(self.orig_vec)
         self.saved = True
 
     def set_geom(self, elem, xyz):
@@ -146,14 +146,14 @@ class BaseMolecule(object):
         if elem is not None:
             self.elem = elem
         self.xyz = np.array(xyz, dtype=float)
-        self.mom = np.zeros_like(xyz)
+        self.vec = np.zeros_like(xyz)
         self._check()
         self.saved = False
 
-    def set_mom(self, mom):
-        """Sets molecular momentum."""
-        self.mom = np.array(mom, dtype=float)
-        self.print_mom = True
+    def set_vec(self, vec):
+        """Sets molecular vector."""
+        self.vec = np.array(vec, dtype=float)
+        self.print_vec = True
         self._check()
         self.saved = False
 
@@ -162,18 +162,18 @@ class BaseMolecule(object):
         self.comment = comment
         self.saved = False
 
-    def add_atoms(self, new_elem, new_xyz, new_mom=None):
+    def add_atoms(self, new_elem, new_xyz, new_vec=None):
         """Adds atoms(s) to molecule."""
         self.natm += 1 if isinstance(new_elem, str) else len(new_elem)
         new_xyz = np.atleast_2d(new_xyz)
         self.elem = np.hstack((self.elem, new_elem))
         self.xyz = np.vstack((self.xyz, new_xyz))
-        if new_mom is None:
-            self.mom = np.vstack((self.mom, np.zeros((len(new_xyz), 3))))
+        if new_vec is None:
+            self.vec = np.vstack((self.vec, np.zeros((len(new_xyz), 3))))
         else:
-            new_mom = np.atleast_2d(new_mom)
-            self.mom = np.vstack((self.mom, new_mom))
-            self.print_mom = True
+            new_vec = np.atleast_2d(new_vec)
+            self.vec = np.vstack((self.vec, new_vec))
+            self.print_vec = True
         self._check()
         self.saved = False
 
@@ -182,7 +182,7 @@ class BaseMolecule(object):
         self.natm -= 1 if isinstance(ind, int) else len(ind)
         self.elem = np.delete(self.elem, ind)
         self.xyz = np.delete(self.xyz, ind, axis=0)
-        self.mom = np.delete(self.mom, ind, axis=0)
+        self.vec = np.delete(self.vec, ind, axis=0)
         self._check()
         self.saved = False
 
@@ -194,7 +194,7 @@ class BaseMolecule(object):
         old = np.hstack((new_ind, old_ind))
         new = np.hstack((old_ind, new_ind))
         self.xyz[old] = self.xyz[new]
-        self.mom[old] = self.mom[new]
+        self.vec[old] = self.vec[new]
         self.elem[old] = self.elem[new]
         self.saved = False
 
@@ -216,7 +216,7 @@ class Molecule(BaseMolecule):
 
     def __str__(self):
         base = BaseMolecule(self.elem[1:], self.xyz[1:],
-                            self.mom[1:] if self.print_mom else None,
+                            self.vec[1:] if self.print_vec else None,
                             self.comment)
         return base.__str__()
 
@@ -231,7 +231,7 @@ class Molecule(BaseMolecule):
         else:
             self.elem = np.hstack(('XM', self.elem))
             self.xyz = np.vstack((pos, self.xyz))
-            self.mom = np.vstack(([0, 0, 0], self.mom))
+            self.vec = np.vstack(([0, 0, 0], self.vec))
 
     def _check(self):
         """Checks that xyz is 3D and len(elem) = len(xyz) and that dummy
@@ -243,29 +243,29 @@ class Molecule(BaseMolecule):
     def copy(self, comment=None):
         """Creates a copy of the Molecule object."""
         self._check()
-        mom = self.mom[1:] if self.print_mom else None
+        vec = self.vec[1:] if self.print_vec else None
         if comment is None:
             comment = self.comment
         return Molecule(np.copy(self.elem[1:]), np.copy(self.xyz[1:]),
-                        mom, comment)
+                        vec, comment)
 
-    def set_mom(self, mom):
-        """Sets the molecular momentum."""
-        new_mom = np.vstack(([0, 0, 0], mom))
-        BaseMolecule.set_mom(self, new_mom)
+    def set_vec(self, vec):
+        """Sets the molecular vector."""
+        new_vec = np.vstack(([0, 0, 0], vec))
+        BaseMolecule.set_vec(self, new_vec)
 
     # Input/Output
-    def read(self, infile, fmt='auto', hasmom=False, hascom=False):
+    def read(self, infile, fmt='auto', hasvec=False, hascom=False):
         """Reads single geometry from input file in provided format."""
         read_func = getattr(fileio, 'read_' + fmt)
         if isinstance(infile, str):
             with open(infile, 'r') as f:
                 (self.elem, self.xyz,
-                 self.mom, self.comment) = read_func(f, hasmom=hasmom,
+                 self.vec, self.comment) = read_func(f, hasvec=hasvec,
                                                      hascom=hascom)
         else:
             (self.elem, self.xyz,
-             self.mom, self.comment) = read_func(infile, hasmom=hasmom,
+             self.vec, self.comment) = read_func(infile, hasvec=hasvec,
                                                  hascom=hascom)
         self.natm = len(self.elem)
         self.save()
@@ -273,13 +273,13 @@ class Molecule(BaseMolecule):
     def write(self, outfile, fmt='auto'):
         """Writes geometry to an output file in provided format."""
         write_func = getattr(fileio, 'write_' + fmt)
-        mom = self.mom[1:] if self.print_mom else None
+        vec = self.vec[1:] if self.print_vec else None
         if isinstance(outfile, str):
             with open(outfile, 'w') as f:
-                write_func(f, self.elem[1:], self.xyz[1:], mom=mom,
+                write_func(f, self.elem[1:], self.xyz[1:], vec=vec,
                            comment=self.comment)
         else:
-            write_func(outfile, self.elem[1:], self.xyz[1:], mom=mom,
+            write_func(outfile, self.elem[1:], self.xyz[1:], vec=vec,
                        comment=self.comment)
 
     # Accessors
@@ -295,9 +295,9 @@ class Molecule(BaseMolecule):
         """Returns cartesian geometry."""
         return self.xyz[1:]
 
-    def get_mom(self):
-        """Return cartesian momenta."""
-        return self.mom[1:]
+    def get_vec(self):
+        """Return cartesian vector."""
+        return self.vec[1:]
 
     def get_comment(self):
         """Returns comment line."""
@@ -368,14 +368,14 @@ class Molecule(BaseMolecule):
                units='rad'):
         """Rotates the molecule about a given axis from a given origin.
 
-        If momenta are non-zero, they will be rotated about the
+        If vectors are non-zero, they will be rotated about the
         same origin. Reflections and improper rotations can be done
         by setting det=-1.
         """
         kwargs = dict(ind=ind, origin=origin, det=det, units=units)
         self.xyz = displace.rotate(self.xyz, amp, axis, **kwargs)
-        if self.print_mom:
-            self.mom = displace.rotate(self.mom, amp, axis, **kwargs)
+        if self.print_vec:
+            self.vec = displace.rotate(self.vec, amp, axis, **kwargs)
         self._add_centre()
         self.saved = False
 
@@ -384,23 +384,23 @@ class Molecule(BaseMolecule):
                      ind=None, cent=None):
         """Tests the molecule against a set of references in a bundle.
 
-        Note: momenta are not properly rotated.
+        Note: vectors are not properly rotated.
         """
-        mom = self.mom[1:] if self.print_mom else None
+        vec = self.vec[1:] if self.print_vec else None
         reflist = [mol.get_xyz() for mol in ref_bundle.get_molecules()]
         kwargs = dict(plist=_atm_inds(plist), equiv=_atm_inds(equiv),
                       wgt=wgt, ind=ind, cent=cent)
         xyz, ind = kabsch.opt_ref(self.get_elem(), self.get_xyz(), reflist,
                                   **kwargs)
-        return Molecule(self.get_elem(), xyz, mom,
+        return Molecule(self.get_elem(), xyz, vec,
                         self.get_comment()), ind
 
     # Functional group substitution
     def subst(self, lbl, isub, ibond, pl=None):
         """Replaces an atom or set of atoms with a substituent."""
         args = (self.elem, self.xyz, lbl, isub, ibond)
-        kwargs = dict(pl=pl, mom=self.mom)
-        self.elem, self.xyz, self.mom = substitute.subst(*args, **kwargs)
+        kwargs = dict(pl=pl, vec=self.vec)
+        self.elem, self.xyz, self.vec = substitute.subst(*args, **kwargs)
 
 
 class MoleculeBundle(object):
@@ -497,12 +497,12 @@ class MoleculeBundle(object):
         self.molecules = np.delete(self.molecules, ind)
 
     # Input/Output
-    def read(self, infile, fmt='auto', hasmom=False, hascom=False):
+    def read(self, infile, fmt='auto', hasvec=False, hascom=False):
         """Reads all geometries from input file in provided format."""
         read_func = getattr(fileio, 'read_' + fmt)
         while True:
             try:
-                new_mol = Molecule(*read_func(infile, hasmom=hasmom,
+                new_mol = Molecule(*read_func(infile, hasvec=hasvec,
                                               hascom=hasccom))
                 self.molecules = np.hstack((self.molecules, new_mol))
                 self.nmol += 1

--- a/geomtools/substitute.py
+++ b/geomtools/substitute.py
@@ -1,0 +1,109 @@
+"""
+Substitution of molecular geometries with functional groups.
+
+Given a cartesian geometry and element labels, a substituent can
+be added knowing (a) the substituent identity (b) the desired
+position to substitute and (c) the bond axis for substitution.
+
+This requires some default information, such as the default structure
+and orientation of the substituent (relative to an axis) and the
+bond length of the substituent. For now, only single bonds are treated.
+"""
+import numpy as np
+import geomtools.displace as displace
+import geomtools.fileio as fileio
+import geomtools.constants as con
+
+
+class SubLib(object):
+    """
+    Object containing a library of substituent geometries.
+    """
+    def __init__(self):
+        self.subs = ['cn', 'ch3']
+        self.elem = dict()
+        self.xyz = dict()
+        self._populate_elem()
+        self._populate_xyz()
+
+    def _populate_elem(self):
+        """Adds element labels to self.elem."""
+        self.elem['cn'] = np.array(['C', 'N'])
+        self.elem['ch3'] = np.array(['C', 'H', 'H', 'H'])
+
+    def _populate_xyz(self):
+        """Adds cartesian geometries to self.xyz."""
+        self.xyz['cn'] = np.array([[0.000, 0.000, 0.000],
+                                   [0.000, 0.000, 1.136]])
+        self.xyz['ch3'] = np.array([[0.000, 0.000, 0.000],
+                                    [-1.023, 0.000, 0.377],
+                                    [0.511, -0.886, 0.377],
+                                    [0.511, 0.886, 0.377]])
+
+    def _parse_label(self, label):
+        """Returns a label in a single format."""
+        return label.lower()
+
+    def get_sub(self, label):
+        lbl = self._parse_label(label)
+        return self.elem[lbl], self.xyz[lbl]
+
+
+def import_sub(label):
+    """Returns the element list and cartesian geometry of a substituent
+    given its label."""
+    lib = SubLib()
+    return lib.get_sub(label)
+
+
+def subst(elem, xyz, sublbl, isub, ibond, iplane=None, mom=None):
+    """Returns a molecular geometry with an specified atom replaced by
+    substituent.
+
+    Labels are case-insensitive. Indices isub, ibond and iplane give
+    the position to be substituted, the position that will be bonded to
+    the substituent (i.e. the axis) and an optional 3rd index to define
+    the plane (if any) of the substituent.
+
+    If isub is given as a list, the entire list of atoms is be removed
+    and the first index is treated as the position of the substituent.
+    """
+    elem = np.array(elem)
+    xyz = np.atleast_2d(xyz)
+    if not isinstance(isub, int):
+        ipos = isub[0]
+    else:
+        isub = [isub]
+        ipos = isub[0]
+
+    ax = xyz[ipos] - xyz[ibond]
+    ax /= np.linalg.norm(ax)
+    origin = xyz[ibond]
+    if iplane is None:
+        pl = np.array([0, 1, 0])
+        pl -= np.dot(pl, ax)
+    else:
+        pl = np.cross(xyz[ipos] - xyz[ibond], xyz[iplane] - xyz[ibond])
+
+    sub_el, sub_xyz = import_sub(sublbl)
+    blen = con.get_covrad(elem[ibond]) + con.get_covrad(sub_el[0])
+
+    # rotate to correct orientation
+    sub_xyz = displace.align_axis(sub_xyz, 'z', ax)
+    sub_pl = displace.align_axis([0, 1, 0], 'z', ax)
+    sub_xyz = displace.align_axis(sub_xyz, sub_pl, pl)
+
+    # displace to correct position
+    sub_xyz += xyz[ibond]
+    sub_xyz += blen * ax
+
+    # build the final geometry
+    ind1 = [i for i in range(ipos) if i not in isub[1:]]
+    ind2 = [i for i in range(ipos+1, len(elem)) if i not in isub[1:]]
+    new_elem = np.hstack((elem[ind1], sub_el, elem[ind2]))
+    new_xyz = np.vstack((xyz[ind1], sub_xyz, xyz[ind2]))
+    if mom is None:
+        new_mom = np.zeros((len(new_elem), 3))
+    else:
+        new_mom = np.vstack((mom[ind1], np.zeros((len(sub_el), 3)), mom[ind2]))
+    return new_elem, new_xyz, new_mom

--- a/geomtools/substitute.py
+++ b/geomtools/substitute.py
@@ -20,29 +20,49 @@ class SubLib(object):
     Object containing a library of substituent geometries.
     """
     def __init__(self):
-        self.subs = ['cn', 'ch3']
         self.elem = dict()
         self.xyz = dict()
+        self.syn = dict()
         self._populate_elem()
         self._populate_xyz()
+        self._populate_syn()
 
     def _populate_elem(self):
         """Adds element labels to self.elem."""
-        self.elem['cn'] = np.array(['C', 'N'])
         self.elem['ch3'] = np.array(['C', 'H', 'H', 'H'])
+        self.elem['nh2'] = np.array(['N', 'H', 'H'])
+        self.elem['oh'] = np.array(['O', 'H'])
+        self.elem['f'] = np.array(['F'])
+        self.elem['cn'] = np.array(['C', 'N'])
+        self.elem['cl'] = np.array(['Cl'])
 
     def _populate_xyz(self):
         """Adds cartesian geometries to self.xyz."""
-        self.xyz['cn'] = np.array([[0.000, 0.000, 0.000],
-                                   [0.000, 0.000, 1.136]])
         self.xyz['ch3'] = np.array([[0.000, 0.000, 0.000],
                                     [-1.023, 0.000, 0.377],
                                     [0.511, -0.886, 0.377],
                                     [0.511, 0.886, 0.377]])
+        self.xyz['nh2'] = np.array([[0.000, 0.000, 0.000],
+                                    [-0.577, -0.771,  0.332],
+                                    [-0.577, 0.771,  0.332]])
+        self.xyz['oh'] = np.array([[0.000, 0.000, 0.000],
+                                   [-0.913, 0.000, 0.297]])
+        self.xyz['f'] = np.array([[0.000, 0.000, 0.000]])
+        self.xyz['cn'] = np.array([[0.000, 0.000, 0.000],
+                                   [0.000, 0.000, 1.136]])
+        self.xyz['cl'] = np.array([[0.000, 0.000, 0.000]])
+
+    def _populate_syn(self):
+        """Adds a dictionary of synonyms for labels."""
+        synlist = [['ch3', 'h3c', 'me'], ['nh2', 'h2n', 'am'], ['oh', 'ho'],
+                   ['f'], ['cn', 'nc'], ['cl']]
+        for subl in synlist:
+            for item in subl:
+                self.syn[item] = subl[0]
 
     def _parse_label(self, label):
         """Returns a label in a single format."""
-        return label.lower()
+        return self.syn[label.lower()]
 
     def get_sub(self, label):
         lbl = self._parse_label(label)
@@ -80,8 +100,8 @@ def subst(elem, xyz, sublbl, isub, ibond, iplane=None, mom=None):
     ax /= np.linalg.norm(ax)
     origin = xyz[ibond]
     if iplane is None:
-        pl = np.array([0., 1., 0.])
-        pl -= np.dot(pl, ax)
+        pl = np.array([1., 1., 1.])
+        pl -= np.dot(pl, ax) * ax
     else:
         pl = np.cross(xyz[ipos] - xyz[ibond], xyz[iplane] - xyz[ibond])
 

--- a/geomtools/substitute.py
+++ b/geomtools/substitute.py
@@ -30,42 +30,86 @@ class SubLib(object):
     def _populate_elem(self):
         """Adds element labels to self.elem."""
         self.elem['ch3'] = np.array(['C', 'H', 'H', 'H'])
+        self.elem['chch2'] = np.array(['C', 'C', 'H', 'H', 'H'])
+        self.elem['cch'] = np.array(['C', 'C', 'H'])
         self.elem['nh2'] = np.array(['N', 'H', 'H'])
-        self.elem['oh'] = np.array(['O', 'H'])
-        self.elem['f'] = np.array(['F'])
+        self.elem['chnh'] = np.array(['C', 'N', 'H', 'H'])
         self.elem['cn'] = np.array(['C', 'N'])
+        self.elem['oh'] = np.array(['O', 'H'])
+        self.elem['cho'] = np.array(['C', 'O', 'H'])
+        self.elem['no2'] = np.array(['N', 'O', 'O'])
+        self.elem['f'] = np.array(['F'])
+        self.elem['sh'] = np.array(['S', 'H'])
+        self.elem['sh'] = np.array(['S', 'H'])
+        self.elem['so2h'] = np.array(['S', 'O', 'O', 'H'])
         self.elem['cl'] = np.array(['Cl'])
 
     def _populate_xyz(self):
-        """Adds cartesian geometries to self.xyz."""
+        """Adds cartesian geometries to self.xyz.
+
+        For all substituents, the bonding atom is at the origin,
+        the bonding axis is the z-axis and the plane axis
+        is the y-axis.
+        """
         self.xyz['ch3'] = np.array([[0.000, 0.000, 0.000],
                                     [-1.023, 0.000, 0.377],
                                     [0.511, -0.886, 0.377],
                                     [0.511, 0.886, 0.377]])
+        self.xyz['chch2'] = np.array([[0.000, 0.000, 0.000],
+                                      [-1.124, 0.000,  0.730],
+                                      [0.971, 0.000, 0.495],
+                                      [-2.095, 0.000, 0.235],
+                                      [-1.067, 0.000, 1.818]])
+        self.xyz['cch'] = np.array([[0.000, 0.000, 0.000],
+                                    [0.000, 0.000, 1.210],
+                                    [0.000, 0.000, 2.280]])
         self.xyz['nh2'] = np.array([[0.000, 0.000, 0.000],
                                     [-0.577, -0.771,  0.332],
                                     [-0.577, 0.771,  0.332]])
-        self.xyz['oh'] = np.array([[0.000, 0.000, 0.000],
-                                   [-0.913, 0.000, 0.297]])
-        self.xyz['f'] = np.array([[0.000, 0.000, 0.000]])
+        self.xyz['chnh'] = np.array([[0.000, 0.000, 0.000],
+                                     [-1.082, 0.000, 0.703],
+                                     [0.980, 0.000, 0.499],
+                                     [-0.869, 0.000, 1.710]])
         self.xyz['cn'] = np.array([[0.000, 0.000, 0.000],
                                    [0.000, 0.000, 1.136]])
+        self.xyz['oh'] = np.array([[0.000, 0.000, 0.000],
+                                   [-0.913, 0.000, 0.297]])
+        self.xyz['cho'] = np.array([[0.000, 0.000, 0.000],
+                                    [-1.011, 0.000, 0.700],
+                                    [0.998, 0.000, 0.463]])
+        self.xyz['no2'] = np.array([[0.000, 0.000, 0.000],
+                                    [-1.105, 0.000, 0.563],
+                                    [1.105, 0.000, 0.563]])
+        self.xyz['f'] = np.array([[0.000, 0.000, 0.000]])
+        self.xyz['sh'] = np.array([[0.000, 0.000, 0.000],
+                                   [-1.331, 0.000, 0.156]])
+        self.xyz['so2h'] = np.array([[0.000, 0.000, 0.000],
+                                     [0.548, -1.266, 0.448],
+                                     [0.548, 1.266, 0.448],
+                                     [-1.311, 0.000, 0.279]])
         self.xyz['cl'] = np.array([[0.000, 0.000, 0.000]])
 
     def _populate_syn(self):
         """Adds a dictionary of synonyms for labels."""
-        synlist = [['ch3', 'h3c', 'me'], ['nh2', 'h2n', 'am'], ['oh', 'ho'],
-                   ['f'], ['cn', 'nc'], ['cl']]
+        synlist = [['ch3', 'h3c', 'me'],
+                   ['chch2', 'c2h3', 'h2chc', 'h3c2', 'vi'],
+                   ['cch', 'c2h', 'hcc', 'hc2', 'ey'],
+                   ['nh2', 'h2n', 'am'],
+                   ['chnh', 'cnh2', 'nhch', 'im'],
+                   ['cn', 'nc'],
+                   ['oh', 'ho'],
+                   ['cho', 'coh', 'och', 'ohc', 'al'],
+                   ['no2', 'o2n', 'nt'],
+                   ['f'],
+                   ['sh', 'hs'],
+                   ['so2h', 'sooh', 'sho2', 'ho2s', 'hso2'],
+                   ['cl']]
         for subl in synlist:
             for item in subl:
                 self.syn[item] = subl[0]
 
-    def _parse_label(self, label):
-        """Returns a label in a single format."""
-        return self.syn[label.lower()]
-
     def get_sub(self, label):
-        lbl = self._parse_label(label)
+        lbl = self.syn[label.lower()]
         return self.elem[lbl], self.xyz[lbl]
 
 
@@ -76,14 +120,15 @@ def import_sub(label):
     return lib.get_sub(label)
 
 
-def subst(elem, xyz, sublbl, isub, ibond, iplane=None, mom=None):
+def subst(elem, xyz, sublbl, isub, ibond, pl=None, mom=None):
     """Returns a molecular geometry with an specified atom replaced by
     substituent.
 
-    Labels are case-insensitive. Indices isub, ibond and iplane give
+    Labels are case-insensitive. Indices isub and ibond give
     the position to be substituted, the position that will be bonded to
-    the substituent (i.e. the axis) and an optional 3rd index to define
-    the plane (if any) of the substituent.
+    the substituent (i.e. the axis). The orientation of the substituent
+    can be given as a vector (the plane normal) or an index (the plane
+    containing isub, ibond and pl).
 
     If isub is given as a list, the entire list of atoms is be removed
     and the first index is treated as the position of the substituent.
@@ -99,14 +144,18 @@ def subst(elem, xyz, sublbl, isub, ibond, iplane=None, mom=None):
     ax = xyz[ipos] - xyz[ibond]
     ax /= np.linalg.norm(ax)
     origin = xyz[ibond]
-    if iplane is None:
+    if pl is None:
+        # choose an arbitrary axis and project out the bond axis
         pl = np.array([1., 1., 1.])
         pl -= np.dot(pl, ax) * ax
-    else:
-        pl = np.cross(xyz[ipos] - xyz[ibond], xyz[iplane] - xyz[ibond])
+    elif isinstance(pl, int):
+        pl = np.cross(xyz[ipos] - xyz[ibond], xyz[pl] - xyz[ibond])
 
     sub_el, sub_xyz = import_sub(sublbl)
-    blen = con.get_covrad(elem[ibond]) + con.get_covrad(sub_el[0])
+    if elem[ipos] == sub_el[0]:
+        blen = np.linalg.norm(xyz[ipos] - xyz[ibond])
+    else:
+        blen = con.get_covrad(elem[ibond]) + con.get_covrad(sub_el[0])
 
     # rotate to correct orientation
     sub_xyz = displace.align_axis(sub_xyz, 'z', ax)

--- a/geomtools/substitute.py
+++ b/geomtools/substitute.py
@@ -201,15 +201,15 @@ def import_sub(label):
     return lib.get_sub(label)
 
 
-def subst(elem, xyz, sublbl, isub, ibond, pl=None, vec=None):
+def subst(elem, xyz, sublbl, isub, ibond=None, pl=None, vec=None):
     """Returns a molecular geometry with an specified atom replaced by
     substituent.
 
-    Labels are case-insensitive. Indices isub and ibond give
-    the position to be substituted, the position that will be bonded to
-    the substituent (i.e. the axis). The orientation of the substituent
-    can be given as a vector (the plane normal) or an index (the plane
-    containing isub, ibond and pl).
+    Labels are case-insensitive. The index isub gives the position to be
+    substituted. If specified, ibond gives the atom bonded to the
+    substituent. Otherwise, the nearest atom to isub is used. The
+    orientation of the substituent can be given as a vector (the plane
+    normal) or an index (the plane containing isub, ibond and pl).
 
     If isub is given as a list, the entire list of atoms is be removed
     and the first index is treated as the position of the substituent.
@@ -221,6 +221,11 @@ def subst(elem, xyz, sublbl, isub, ibond, pl=None, vec=None):
     else:
         isub = [isub]
         ipos = isub[0]
+
+    if ibond is None:
+        dist = np.linalg.norm(xyz - xyz[isub], axis=1)
+        dist[isub] += np.max(dist)
+        ibond = np.argmin(dist)
 
     ax = xyz[ipos] - xyz[ibond]
     ax /= np.linalg.norm(ax)

--- a/geomtools/substitute.py
+++ b/geomtools/substitute.py
@@ -20,28 +20,30 @@ class SubLib(object):
     Object containing a library of substituent geometries.
     """
     def __init__(self):
+        self.syn = dict()
         self.elem = dict()
         self.xyz = dict()
-        self.syn = dict()
+        self._populate_syn()
         self._populate_elem()
         self._populate_xyz()
-        self._populate_syn()
+        self._add_comb()
 
     def _populate_elem(self):
         """Adds element labels to self.elem."""
-        self.elem['ch3'] = np.array(['C', 'H', 'H', 'H'])
-        self.elem['chch2'] = np.array(['C', 'C', 'H', 'H', 'H'])
-        self.elem['cch'] = np.array(['C', 'C', 'H'])
-        self.elem['nh2'] = np.array(['N', 'H', 'H'])
-        self.elem['chnh'] = np.array(['C', 'N', 'H', 'H'])
+        self.elem['me'] = np.array(['C', 'H', 'H', 'H'])
+        self.elem['vi'] = np.array(['C', 'C', 'H', 'H', 'H'])
+        self.elem['ey'] = np.array(['C', 'C', 'H'])
+        self.elem['ph'] = np.array(['C', 'C', 'C', 'C', 'C', 'C',
+                                    'H', 'H', 'H', 'H', 'H'])
+        self.elem['am'] = np.array(['N', 'H', 'H'])
+        self.elem['im'] = np.array(['C', 'N', 'H', 'H'])
         self.elem['cn'] = np.array(['C', 'N'])
         self.elem['oh'] = np.array(['O', 'H'])
-        self.elem['cho'] = np.array(['C', 'O', 'H'])
-        self.elem['no2'] = np.array(['N', 'O', 'O'])
+        self.elem['al'] = np.array(['C', 'O', 'H'])
+        self.elem['nt'] = np.array(['N', 'O', 'O'])
         self.elem['f'] = np.array(['F'])
         self.elem['sh'] = np.array(['S', 'H'])
-        self.elem['sh'] = np.array(['S', 'H'])
-        self.elem['so2h'] = np.array(['S', 'O', 'O', 'H'])
+        self.elem['sf'] = np.array(['S', 'O', 'O', 'H'])
         self.elem['cl'] = np.array(['Cl'])
 
     def _populate_xyz(self):
@@ -51,66 +53,145 @@ class SubLib(object):
         the bonding axis is the z-axis and the plane axis
         is the y-axis.
         """
-        self.xyz['ch3'] = np.array([[0.000, 0.000, 0.000],
-                                    [-1.023, 0.000, 0.377],
-                                    [0.511, -0.886, 0.377],
-                                    [0.511, 0.886, 0.377]])
-        self.xyz['chch2'] = np.array([[0.000, 0.000, 0.000],
-                                      [-1.124, 0.000,  0.730],
-                                      [0.971, 0.000, 0.495],
-                                      [-2.095, 0.000, 0.235],
-                                      [-1.067, 0.000, 1.818]])
-        self.xyz['cch'] = np.array([[0.000, 0.000, 0.000],
-                                    [0.000, 0.000, 1.210],
-                                    [0.000, 0.000, 2.280]])
-        self.xyz['nh2'] = np.array([[0.000, 0.000, 0.000],
-                                    [-0.577, -0.771,  0.332],
-                                    [-0.577, 0.771,  0.332]])
-        self.xyz['chnh'] = np.array([[0.000, 0.000, 0.000],
-                                     [-1.082, 0.000, 0.703],
-                                     [0.980, 0.000, 0.499],
-                                     [-0.869, 0.000, 1.710]])
-        self.xyz['cn'] = np.array([[0.000, 0.000, 0.000],
-                                   [0.000, 0.000, 1.136]])
-        self.xyz['oh'] = np.array([[0.000, 0.000, 0.000],
-                                   [-0.913, 0.000, 0.297]])
-        self.xyz['cho'] = np.array([[0.000, 0.000, 0.000],
-                                    [-1.011, 0.000, 0.700],
-                                    [0.998, 0.000, 0.463]])
-        self.xyz['no2'] = np.array([[0.000, 0.000, 0.000],
-                                    [-1.105, 0.000, 0.563],
-                                    [1.105, 0.000, 0.563]])
-        self.xyz['f'] = np.array([[0.000, 0.000, 0.000]])
-        self.xyz['sh'] = np.array([[0.000, 0.000, 0.000],
-                                   [-1.331, 0.000, 0.156]])
-        self.xyz['so2h'] = np.array([[0.000, 0.000, 0.000],
-                                     [0.548, -1.266, 0.448],
-                                     [0.548, 1.266, 0.448],
-                                     [-1.311, 0.000, 0.279]])
-        self.xyz['cl'] = np.array([[0.000, 0.000, 0.000]])
+        self.xyz['me'] = np.array([[ 0.000,  0.000,  0.000],
+                                   [ 0.511, -0.886,  0.377],
+                                   [ 0.511,  0.886,  0.377],
+                                   [-1.023,  0.000,  0.377]])
+        self.xyz['vi'] = np.array([[ 0.000,  0.000,  0.000],
+                                   [-1.124,  0.000,  0.730],
+                                   [ 0.971,  0.000,  0.495],
+                                   [-1.067,  0.000,  1.818],
+                                   [-2.095,  0.000,  0.235]])
+        self.xyz['ey'] = np.array([[ 0.000,  0.000,  0.000],
+                                   [ 0.000,  0.000,  1.210],
+                                   [ 0.000,  0.000,  2.280]])
+        self.xyz['ph'] = np.array([[ 0.000,  0.000,  0.000],
+                                   [-1.212,  0.000,  0.700],
+                                   [ 1.212,  0.000,  0.700],
+                                   [-1.212,  0.000,  2.100],
+                                   [ 1.212,  0.000,  2.100],
+                                   [ 0.000,  0.000,  2.800],
+                                   [-2.156,  0.000,  0.155],
+                                   [ 2.156,  0.000,  0.155],
+                                   [-2.156,  0.000,  2.645],
+                                   [ 2.156,  0.000,  2.645],
+                                   [ 0.000,  0.000,  3.890]])
+        self.xyz['am'] = np.array([[ 0.000,  0.000,  0.000],
+                                   [-0.577, -0.771,  0.332],
+                                   [-0.577,  0.771,  0.332]])
+        self.xyz['im'] = np.array([[ 0.000,  0.000,  0.000],
+                                   [-1.082,  0.000,  0.703],
+                                   [ 0.980,  0.000,  0.499],
+                                   [-0.869,  0.000,  1.710]])
+        self.xyz['cn'] = np.array([[ 0.000,  0.000,  0.000],
+                                   [ 0.000,  0.000,  1.136]])
+        self.xyz['oh'] = np.array([[ 0.000,  0.000,  0.000],
+                                   [-0.913,  0.000,  0.297]])
+        self.xyz['al'] = np.array([[ 0.000,  0.000,  0.000],
+                                   [-1.011,  0.000,  0.700],
+                                   [ 0.998,  0.000,  0.463]])
+        self.xyz['nt'] = np.array([[ 0.000,  0.000,  0.000],
+                                   [-1.105,  0.000,  0.563],
+                                   [ 1.105,  0.000,  0.563]])
+        self.xyz['f'] = np.array([[ 0.000,  0.000,  0.000]])
+        self.xyz['sh'] = np.array([[ 0.000,  0.000,  0.000],
+                                   [-1.331,  0.000,  0.156]])
+        self.xyz['sf'] = np.array([[ 0.000,  0.000,  0.000],
+                                   [ 0.548, -1.266,  0.448],
+                                   [ 0.548,  1.266,  0.448],
+                                   [-1.311,  0.000,  0.279]])
+        self.xyz['cl'] = np.array([[ 0.000,  0.000,  0.000]])
+
+    def _add_comb(self):
+        """Adds substituents made by combining multiple substituents."""
+        self.elem['et'], self.xyz['et'] = self.add_subs('me', 'me')
+        self.elem['npr'], self.xyz['npr'] = self.add_subs('me', 'me', 'me')
+        self.elem['ipr'], self.xyz['ipr'] = self.add_subs('me', 'me', 'me',
+                                                          inds=1)
+        self.elem['nbu'], self.xyz['nbu'] = self.add_subs('me', 'me', 'me',
+                                                          'me')
+        self.elem['ibu'], self.xyz['ibu'] = self.add_subs('me', 'me', 'me',
+                                                          'me', inds=[2, 1, -1])
+        self.elem['tbu'], self.xyz['tbu'] = self.add_subs('me', 'me', 'me',
+                                                          'me', inds=1)
+        self.elem['ome'], self.xyz['ome'] = self.add_subs('oh', 'me')
+        self.elem['ac'], self.xyz['ac'] = self.add_subs('al', 'me')
+        self.elem['ca'], self.xyz['ca'] = self.add_subs('al', 'oh')
+        self.elem['tfm'], self.xyz['tfm'] = self.add_subs('me', 'f', 'f', 'f',
+                                                          inds=1)
+        self.elem['ms'], self.xyz['ms'] = self.add_subs('sf', 'me')
 
     def _populate_syn(self):
         """Adds a dictionary of synonyms for labels."""
-        synlist = [['ch3', 'h3c', 'me'],
-                   ['chch2', 'c2h3', 'h2chc', 'h3c2', 'vi'],
-                   ['cch', 'c2h', 'hcc', 'hc2', 'ey'],
-                   ['nh2', 'h2n', 'am'],
-                   ['chnh', 'cnh2', 'nhch', 'im'],
+        synlist = [['me', 'ch3', 'h3c'],
+                   ['et', 'ch2ch3', 'c2h5', 'ch3ch2'],
+                   ['npr', 'ch2ch2ch3', 'c3h7', 'ch3ch2ch2'],
+                   ['ipr', 'chch3ch3', 'ch(ch3)2', '(ch3)2ch', 'ch3chch3'],
+                   ['nbu', 'ch2ch2ch2ch3', 'c4h9', 'ch3ch2ch2ch2'],
+                   ['ibu', 'chch3ch2ch3', 'ch3chch2ch3', 'ch3ch3chch3'],
+                   ['tbu', 'cch3ch3ch3', 'c(ch3)3', 'ch3ch3ch3c', '(ch3)3c'],
+                   ['vi', 'chch2', 'c2h3', 'h2chc', 'h3c2'],
+                   ['ey', 'cch', 'c2h', 'hcc', 'hc2'],
+                   ['ph', 'c6h5', 'h5c6'],
+                   ['am', 'nh2', 'h2n'],
+                   ['im', 'chnh', 'cnh2', 'nhch'],
                    ['cn', 'nc'],
                    ['oh', 'ho'],
-                   ['cho', 'coh', 'och', 'ohc', 'al'],
-                   ['no2', 'o2n', 'nt'],
+                   ['ome', 'meo', 'och3', 'ch3o'],
+                   ['al', 'cho', 'coh', 'och', 'ohc'],
+                   ['ac', 'coch3', 'cch3o'],
+                   ['ca', 'cooh', 'co2h', 'hooc', 'ho2c'],
+                   ['nt', 'no2', 'o2n'],
                    ['f'],
+                   ['tfm', 'cf3', 'f3c'],
                    ['sh', 'hs'],
-                   ['so2h', 'sooh', 'sho2', 'ho2s', 'hso2'],
+                   ['sf', 'so2h', 'sooh', 'sho2', 'ho2s', 'hso2'],
+                   ['ms', 'sfme', 'mesf', 'sfch3', 'so2me', 'so2ch3'],
                    ['cl']]
         for subl in synlist:
             for item in subl:
                 self.syn[item] = subl[0]
 
     def get_sub(self, label):
+        """Returns the element list and cartesian geometry of a
+        substituent."""
         lbl = self.syn[label.lower()]
         return self.elem[lbl], self.xyz[lbl]
+
+    def add_subs(self, *lbls, inds=-1):
+        """Returns the element list and cartesian geometry from a
+        combination of substituents.
+
+        By default, the last atom becomes the substituted atom and the
+        new substituent is added at the final indices. Setting inds will
+        substitute the element at that index or list of indices.
+        """
+        if isinstance(inds, int):
+            inds = (len(lbls) - 1) * [inds]
+        elif len(inds) != len(lbls) - 1:
+            raise ValueError('Number of inds != number of labels - 1')
+
+        rot = 0
+        lbl0 = self.syn[lbls[0].lower()]
+        elem = self.elem[lbl0]
+        xyz = self.xyz[lbl0]
+        for i, label in zip(inds, lbls[1:]):
+            dist = np.linalg.norm(xyz - xyz[i], axis=1)
+            dist[i] += np.max(dist)
+            ibond = np.argmin(dist)
+            rot = (rot + 1) % 2
+            ax = xyz[i] - xyz[ibond]
+            ax /= np.linalg.norm(ax)
+            lbl = self.syn[label.lower()]
+            new_elem = self.elem[lbl]
+            new_xyz = displace.rotate(self.xyz[lbl], rot*np.pi, 'z')
+            new_xyz = displace.align_axis(new_xyz, 'z', ax)
+            blen = con.get_covrad(elem[ibond]) + con.get_covrad(new_elem[0])
+            new_xyz += xyz[ibond] + blen * ax
+            elem = np.hstack((np.delete(elem, i), new_elem))
+            xyz = np.vstack((np.delete(xyz, i, axis=0), new_xyz))
+
+        return elem, xyz
 
 
 def import_sub(label):
@@ -120,7 +201,7 @@ def import_sub(label):
     return lib.get_sub(label)
 
 
-def subst(elem, xyz, sublbl, isub, ibond, pl=None, mom=None):
+def subst(elem, xyz, sublbl, isub, ibond, pl=None, vec=None):
     """Returns a molecular geometry with an specified atom replaced by
     substituent.
 
@@ -143,10 +224,9 @@ def subst(elem, xyz, sublbl, isub, ibond, pl=None, mom=None):
 
     ax = xyz[ipos] - xyz[ibond]
     ax /= np.linalg.norm(ax)
-    origin = xyz[ibond]
     if pl is None:
         # choose an arbitrary axis and project out the bond axis
-        pl = np.array([1., 1., 1.])
+        pl = np.ones(3)
         pl -= np.dot(pl, ax) * ax
     elif isinstance(pl, int):
         pl = np.cross(xyz[ipos] - xyz[ibond], xyz[pl] - xyz[ibond])
@@ -163,16 +243,16 @@ def subst(elem, xyz, sublbl, isub, ibond, pl=None, mom=None):
     sub_xyz = displace.align_axis(sub_xyz, sub_pl, pl)
 
     # displace to correct position
-    sub_xyz += xyz[ibond]
-    sub_xyz += blen * ax
+    sub_xyz += xyz[ibond] + blen * ax
 
     # build the final geometry
     ind1 = [i for i in range(ipos) if i not in isub[1:]]
     ind2 = [i for i in range(ipos+1, len(elem)) if i not in isub[1:]]
     new_elem = np.hstack((elem[ind1], sub_el, elem[ind2]))
     new_xyz = np.vstack((xyz[ind1], sub_xyz, xyz[ind2]))
-    if mom is None:
-        new_mom = np.zeros((len(new_elem), 3))
+    if vec is None:
+        new_vec = np.zeros((len(new_elem), 3))
     else:
-        new_mom = np.vstack((mom[ind1], np.zeros((len(sub_el), 3)), mom[ind2]))
-    return new_elem, new_xyz, new_mom
+        new_vec = np.vstack((vec[ind1], np.zeros((len(sub_el), 3)), vec[ind2]))
+
+    return new_elem, new_xyz, new_vec

--- a/geomtools/substitute.py
+++ b/geomtools/substitute.py
@@ -80,7 +80,7 @@ def subst(elem, xyz, sublbl, isub, ibond, iplane=None, mom=None):
     ax /= np.linalg.norm(ax)
     origin = xyz[ibond]
     if iplane is None:
-        pl = np.array([0, 1, 0])
+        pl = np.array([0., 1., 0.])
         pl -= np.dot(pl, ax)
     else:
         pl = np.cross(xyz[ipos] - xyz[ibond], xyz[iplane] - xyz[ibond])
@@ -90,7 +90,7 @@ def subst(elem, xyz, sublbl, isub, ibond, iplane=None, mom=None):
 
     # rotate to correct orientation
     sub_xyz = displace.align_axis(sub_xyz, 'z', ax)
-    sub_pl = displace.align_axis([0, 1, 0], 'z', ax)
+    sub_pl = displace.align_axis([0., 1., 0.], 'z', ax)
     sub_xyz = displace.align_axis(sub_xyz, sub_pl, pl)
 
     # displace to correct position


### PR DESCRIPTION
The substitute module can be used to get preset geometries for functional groups and to add them to a molecular geometry. This includes the new method for Molecule, `subst`, which can add a substituent at a specific position.

The variable `mom` has been changed in favour of the more general `vec`. In the future, a Molecule object should be able to store multiple vectors which can be transformed with rotations.